### PR TITLE
Changed package name to the rosbot_bringup

### DIFF
--- a/demo/compose.rosbot.yaml
+++ b/demo/compose.rosbot.yaml
@@ -28,4 +28,4 @@ services:
       - ROS_MASTER_URI=http://ros-master:11311
     command: >
       roslaunch --wait
-      rosbot_description rosbot_docker.launch
+      rosbot_bringup rosbot_docker.launch


### PR DESCRIPTION
Bugfix - new name of the package
rosbot_description is now named rosbot_bringup